### PR TITLE
Fixed .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,15 @@ python:
     - "2.7"
     - "3.3"
     - "3.4"
+    - "3.5"
 
 install:
     - pip install -r requirements.txt coverage python-coveralls
     - python setup.py --quiet install
 
 script:
-    - python fredapi/tests/test_fred.py -v
-    # For some reason, running the tests like this does not work for
-    # python 2.7 and 3.4:
-    # - python -m unittest fredapi/tests/test_fred.py -v
-    # - python setup.py test
+    - python setup.py test
 
 after_success:
-    - coverage run --source massedit tests.py
+    - coverage run --source fredapi.fred fredapi/tests/test_fred.py
     - coveralls

--- a/fredapi/tests/__init__.py
+++ b/fredapi/tests/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# This file is needed by Python 2.7 to figure that tests is a package.

--- a/fredapi/tests/test_fred.py
+++ b/fredapi/tests/test_fred.py
@@ -235,7 +235,6 @@ class TestFred(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             self.fred.get_series('SP500',
                                  observation_start='invalid-datetime-str')
-        self.assertEqual(str(context.exception), 'Unknown string format')
         self.assertFalse(urlopen.called)
 
     @mock.patch('fredapi.fred.urlopen')


### PR DESCRIPTION
Now relies on standard python setup.py test.  Fixed coverage call. Added
testing for Python 3.5.

Fixed Python2.7 setup.py test by adding __init__.py to let Python 2.7 know
that fredapi.tests is a package.

Also fixed test_invalid_kwarg_in_get_series() which depends on a
(changing) diagnostics.