### PR TITLE
Fix pd.Timestamp.to_datetime() deprecation issue.

### DIFF
--- a/fredapi/fred.py
+++ b/fredapi/fred.py
@@ -72,9 +72,9 @@ class Fred(object):
         """
         helper function for parsing FRED date string into datetime
         """
-        rv = pd.datetime.strptime(date_str, format)
-        if hasattr(rv, 'to_datetime'):
-            rv = rv.to_datetime()
+        rv = pd.to_datetime(date_str, format=format)
+        # if hasattr(rv, 'to_datetime'):
+            # rv = rv.to_datetime()
         return rv
 
     def get_series_info(self, series_id):

--- a/fredapi/fred.py
+++ b/fredapi/fred.py
@@ -72,7 +72,7 @@ class Fred(object):
         """
         helper function for parsing FRED date string into datetime
         """
-        rv = pd.to_datetime(date_str, format=format)
+        rv = pd.datetime.strptime(date_str, format)
         if hasattr(rv, 'to_datetime'):
             rv = rv.to_datetime()
         return rv


### PR DESCRIPTION
`pd.to_datetime()` is going to be deprecated. Replaced this code to use `pd.datetime.strptime()`.

Hope this works for you. Thanks.
