### PR TITLE
add optional realtime_start/end arguments to get_series_all_releases()

### DIFF
--- a/fredapi/fred.py
+++ b/fredapi/fred.py
@@ -200,7 +200,7 @@ class Fred:
         data = df[df['realtime_start'] <= as_of_date]
         return data
 
-    def get_series_all_releases(self, series_id):
+    def get_series_all_releases(self, series_id, realtime_start=None, realtime_end=None):
         """
         Get all data for a Fred series id including first releases and all revisions. This returns a DataFrame
         with three columns: 'date', 'realtime_start', and 'value'. For instance, the US GDP for Q4 2013 was first released
@@ -213,6 +213,10 @@ class Fred:
         ----------
         series_id : str
             Fred series id such as 'GDP'
+        realtime_start : str, optional
+            specifies the realtime_start value used in the query, defaults to the earliest possible start date allowed by Fred
+        realtime_end : str, optional
+            specifies the realtime_end value used in the query, defaults to the latest possible end date allowed by Fred
 
         Returns
         -------
@@ -220,10 +224,14 @@ class Fred:
             a DataFrame with columns 'date', 'realtime_start' and 'value' where 'date' is the observation period and 'realtime_start'
             is when the corresponding value (either first release or revision) is reported.
         """
+        if realtime_start is None:
+            realtime_start = self.earliest_realtime_start
+        if realtime_end is None:
+            realtime_end = self.latest_realtime_end
         url = "%s/series/observations?series_id=%s&realtime_start=%s&realtime_end=%s" % (self.root_url,
                                                                                          series_id,
-                                                                                         self.earliest_realtime_start,
-                                                                                         self.latest_realtime_end)
+                                                                                         realtime_start,
+                                                                                         realtime_end)
         root = self.__fetch_data(url)
         if root is None:
             raise ValueError('No data exists for series id: ' + series_id)

--- a/fredapi/fred.py
+++ b/fredapi/fred.py
@@ -19,7 +19,7 @@ urlencode = url_parse.urlencode
 HTTPError = url_error.HTTPError
 
 
-class Fred(object):
+class Fred:
     earliest_realtime_start = '1776-07-04'
     latest_realtime_end = '9999-12-31'
     nan_char = '.'

--- a/fredapi/tests/test_fred.py
+++ b/fredapi/tests/test_fred.py
@@ -3,17 +3,13 @@ import sys
 if sys.version_info[0] >= 3:
     unicode = str
 
-import os
 import io
 import unittest
 if sys.version_info < (3, 3):
     import mock  # pylint: disable=import-error
 else:
     from unittest import mock  # pylint: disable=import-error
-import datetime as dt
 import textwrap
-import contextlib
-import pandas as pd
 import fredapi
 import fredapi.fred
 
@@ -27,7 +23,7 @@ if not fake_fred_call:
     fred_api_key = fredapi.Fred().api_key
 
 
-class HTTPCall(object):
+class HTTPCall:
     """Encapsulates faked Fred call data."""
 
     root_url = fredapi.Fred.root_url

--- a/fredapi/version.py
+++ b/fredapi/version.py
@@ -1,2 +1,2 @@
 
-version = '0.4.3'
+version = '0.5.0'


### PR DESCRIPTION
Issue raised here: https://github.com/mortada/fredapi/issues/28 https://github.com/mortada/fredapi/issues/48

tested with:
```
In [2]: from fredapi import Fred
   ...: fred = Fred()
   ...: d = fred.get_series_all_releases('DFF', realtime_start='2020-10-01', realtime_end='2022-03-10')

In [3]: d
Out[3]:
      realtime_start       date value
0         2020-10-01 1954-07-01  1.13
1         2020-10-01 1954-07-02  1.25
2         2020-10-01 1954-07-03  1.25
3         2020-10-01 1954-07-04  1.25
4         2020-10-01 1954-07-05  0.88
...              ...        ...   ...
24719     2022-03-08 2022-03-05  0.08
24720     2022-03-08 2022-03-06  0.08
24721     2022-03-08 2022-03-07  0.08
24722     2022-03-09 2022-03-08  0.08
24723     2022-03-10 2022-03-09  0.08

[24724 rows x 3 columns]
```