### PR TITLE
Added a method to retrieve the next scheduled release date for a series 

### DIFF
--- a/fredapi/fred.py
+++ b/fredapi/fred.py
@@ -336,7 +336,7 @@ class Fred:
 
     def get_series_next_release_date(self, series_id, realtime_start=None):
         """
-        Get the next anticipated release date for a series.
+        Get the next scheduled release date for a series.
 
         Parameters
         ----------


### PR DESCRIPTION
In order to get the scheduled release rate we have to first look up the "release" publication for the series and then fetch release dates for that release in the future having no data yet.

I also fixed the observation data test where FRED is not returning data for SP500 > 10 years in the past.